### PR TITLE
If using build_mode FILENAME, create the .build directory if it doesn't exist

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,13 +35,28 @@ data "aws_region" "current" {
   count = var.enabled && var.build_mode != "DISABLED" ? 1 : 0
 }
 
+resource "null_resource" "dir" {
+  count = var.enabled && var.build_mode == "FILENAME" && length(var.output_dir) > 0 ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "[ -d ${var.output_dir} ] || mkdir ${var.output_dir}"
+  }
+}
+
 module "source_zip_file" {
   source = "github.com/alteredparadox/terraform-archive-stable?ref=master"
+  depends_on = [null_resource.dir[0]]
 
   enabled = var.enabled && var.build_mode != "DISABLED"
 
   empty_dirs  = var.empty_dirs
-  output_path = var.enabled && var.build_mode == "FILENAME" ? var.filename : var.enabled && var.build_mode != "DISABLED" ? "${path.module}/zip_files/${data.aws_partition.current[0].partition}-${data.aws_region.current[0].name}-${data.aws_caller_identity.current[0].account_id}-${var.function_name}.zip" : ""
+  output_path = var.enabled && var.build_mode == "FILENAME"
+    ? length(var.output_dir) > 0
+      ? "${var.output_dir}/${var.filename}"
+      : var.filename
+    : var.enabled && var.build_mode != "DISABLED"
+      ? "${path.module}/zip_files/${data.aws_partition.current[0].partition}-${data.aws_region.current[0].name}-${data.aws_caller_identity.current[0].account_id}-${var.function_name}.zip"
+      : ""
   source_dir  = var.source_dir
 }
 
@@ -181,7 +196,7 @@ resource "aws_lambda_function" "built" {
   count = var.enabled ? 1 : 0
 
   description                    = var.description
-  filename                       = var.filename
+  filename                       = length(var.output_dir) > 0 ? "${var.output_dir}/${var.filename}" : var.filename
   function_name                  = var.function_name
   handler                        = var.handler
   kms_key_arn                    = var.kms_key_arn

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,12 @@ variable "memory_size" {
   default     = null
 }
 
+variable "output_dir" {
+  description = "Local directory for the filename to be stored."
+  type        = string
+  default     = ""
+}
+
 variable "publish" {
   description = "Whether to publish creation/change as new Lambda Function Version."
   type        = bool


### PR DESCRIPTION
This was needed to allow the file to be created in a new subdir instead of only one that already existed or the root dir.